### PR TITLE
Fix warning for Apt_Key

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -6,7 +6,7 @@ class rabbitmq::repo::apt(
   $release     = 'testing',
   $repos       = 'main',
   $include_src = false,
-  $key         = '056E8E56',
+  $key         = 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56',
   $key_source  = 'http://www.rabbitmq.com/rabbitmq-signing-key-public.asc',
   ) {
 


### PR DESCRIPTION
Warning: /Apt_key[Add key: 056E8E56 from Apt::Source rabbitmq]: The id should be a full fingerprint (40 characters), see README.
